### PR TITLE
Type stability improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Jeremy Jorgensen <jerjorg@gmail.com>"]
 version = "0.1.5"
 
 [deps]
-CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -16,7 +15,6 @@ SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CDDLib = "0.9"
 Combinatorics = "1.0"
 Distances = "0.10"
 Documenter = "0.26"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Jeremy Jorgensen <jerjorg@gmail.com>"]
 version = "0.1.5"
 
 [deps]
+CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,6 +16,7 @@ SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+CDDLib = "0.9"
 Combinatorics = "1.0"
 Distances = "0.10"
 Documenter = "0.26"

--- a/Project.toml
+++ b/Project.toml
@@ -26,8 +26,9 @@ SymPy = "1.0"
 julia = "1.6"
 
 [extras]
+CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 
 [targets]
-test = ["SymPy"]
+test = ["SymPy", "CDDLib"]

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -133,7 +133,7 @@ function plot_3Dconvexhull(convexhull::Chull{<:Real}, ax::Union{PyObject,Nothing
     p=art3d.Poly3DCollection(faces, alpha=alpha, facecolors=facecolors)
     l=art3d.Line3DCollection(edges, colors=edgecolors,linewidths=linewidths)
 
-    if ax == nothing
+    if ax == nothing 
         fig = figure()
         ax = fig.add_subplot(111, projection="3d")
     end

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -1,10 +1,9 @@
 module Plotting
 
 ENV["MPLBACKEND"]="qt5agg"
-include("Symmetry.jl")
-include("Utilities.jl")
-import .Symmetry: calc_bz, calc_ibz
-import .Utilities: get_uniquefacets
+
+import ..Symmetry: calc_bz, calc_ibz
+import ..Utilities: get_uniquefacets
 import QHull: Chull
 import PyCall: PyObject, pyimport
 import PyPlot: figaspect, figure, subplots
@@ -134,7 +133,7 @@ function plot_3Dconvexhull(convexhull::Chull{<:Real}, ax::Union{PyObject,Nothing
     p=art3d.Poly3DCollection(faces, alpha=alpha, facecolors=facecolors)
     l=art3d.Line3DCollection(edges, colors=edgecolors,linewidths=linewidths)
 
-    if ax == nothing 
+    if ax == nothing
         fig = figure()
         ax = fig.add_subplot(111, projection="3d")
     end

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -7,10 +7,8 @@ import QHull: chull, Chull
 import Combinatorics: permutations
 import Base.Iterators: product, flatten
 
-include("Lattices.jl")
-include("Utilities.jl")
-import .Lattices: get_recip_latvecs, minkowski_reduce
-import .Utilities: sample_circle, sample_sphere, contains, unique_points, remove_duplicates
+import ..Lattices: get_recip_latvecs, minkowski_reduce
+import ..Utilities: sample_circle, sample_sphere, contains, unique_points, remove_duplicates
 
 @doc """
     calc_pointgroup(latvecs;rtol,atol)
@@ -18,7 +16,7 @@ import .Utilities: sample_circle, sample_sphere, contains, unique_points, remove
 Calculate the point group of a lattice in 2D or 3D.
 
 # Arguments
-- `latvecs::AbstractMatrix{<:Real}`: the basis of the lattice as columns of a 
+- `latvecs::AbstractMatrix{<:Real}`: the basis of the lattice as columns of a
     matrix.
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))`: a relative tolerance for
     floating point comparisons. It is used to compare lengths of vectors and the
@@ -511,7 +509,7 @@ Calculate the Brillouin zone for the given real-space lattice basis.
 - `real_latvecs::AbstractMatrix{<:Real}`: the real-space lattice vectors or
     primitive translation vectors as columns of a 2x2 or 3x3 matrix.
 - `atom_typesAbstractVector{<:Int}`: a list of atom types as integers.
-- `atom_pos::AbstractMatrix{<:Real}`: the positions of atoms in the crystal 
+- `atom_pos::AbstractMatrix{<:Real}`: the positions of atoms in the crystal
     structure as columns of a matrix.
 - `coordinates::String`: indicates the positions of the atoms are in \"lattice\"
     or \"Cartesian\" coordinates.
@@ -758,7 +756,7 @@ coordinates = "Cartesian"
 convention = "ordinary"
 make_primitive(real_latvecs, atom_types, atom_pos, coordinates)
 # output
-([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0]) 
+([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0])
 ```
 """
 function make_primitive(real_latvecs::AbstractMatrix{<:Real},
@@ -777,9 +775,9 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
 
     # No need to consider the origin.
     dim = size(real_latvecs,1)
-    if dim==2 
+    if dim==2
         origin=[0.,0.]
-    elseif dim==3 
+    elseif dim==3
         origin=[0.,0.,0.]
     else
         throw(ArgumentError("Can only make 2D or 3D unit cells primitive."))
@@ -802,7 +800,7 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
         if dim == 2
             iters = [[(i,j) for j=i+1:nopts-1] for i=1:nopts-2] |> flatten
         else
-            iters = [[[(i,j,k) for k=j+1:nopts] for j=i+1:nopts-1] for 
+            iters = [[[(i,j,k) for k=j+1:nopts] for j=i+1:nopts-1] for
                 i=1:nopts-2] |> flatten |> flatten
         end
 
@@ -826,7 +824,7 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
             end
         end
     end
-    
+
     if !mapped
         prim_latvecs = real_latvecs
         inv_latvecs = inv(real_latvecs)
@@ -855,11 +853,11 @@ Complete the orbit of a point.
 
 # Arguments
 - `pt::AbstractVector{<:Real}`: the Cartesian coordinates of a point.
-- `pointgroup::Vector{Matrix{Float64}}`: the point group operators 
-    in a nested list. The operators operate on points in Cartesian coordinates 
+- `pointgroup::Vector{Matrix{Float64}}`: the point group operators
+    in a nested list. The operators operate on points in Cartesian coordinates
     from the right.
 - `rtol::Real=sqrt(eps(float(maximum(pt))))`: a relative tolerance.
-- `atol::Real=1e-9`: an absolute tolerance. 
+- `atol::Real=1e-9`: an absolute tolerance.
 
 # Returns
 - `::AbstractMatrix{<:Real}`: the points of the orbit in Cartesian coordinates as
@@ -892,10 +890,10 @@ Complete the orbits of multiple points.
 # Arguments
 - `pt::AbstractMatrix{<:Real}`: the Cartesian coordinates of a points as columns of
     a matrix.
-- `pointgroup::Vector{Matrix{Float64}}`: the point group operators 
+- `pointgroup::Vector{Matrix{Float64}}`: the point group operators
     in a nested list. The operators operate on points in Cartesian coordinates from the right.
 - `rtol::Real=sqrt(eps(float(maximum(pt))))`: a relative tolerance.
-- `atol::Real=1e-9`: an absolute tolerance. 
+- `atol::Real=1e-9`: an absolute tolerance.
 
 # Returns
 - `::AbstractMatrix{<:Real}`: the unique points of the orbits in Cartesian coordinates as

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -1,8 +1,7 @@
 module Symmetry
 
-import CDDLib: Library
-import Polyhedra: HalfSpace, polyhedron, points
-import LinearAlgebra: norm, det, I, dot
+import Polyhedra: HalfSpace, polyhedron, points, Intersection, Library, DefaultLibrary
+import LinearAlgebra: norm, det, I, dot, checksquare
 import QHull: chull, Chull
 import Combinatorics: permutations
 import Base.Iterators: product, flatten
@@ -16,7 +15,7 @@ import ..Utilities: sample_circle, sample_sphere, contains, unique_points, remov
 Calculate the point group of a lattice in 2D or 3D.
 
 # Arguments
-- `latvecs::AbstractMatrix{<:Real}`: the basis of the lattice as columns of a 
+- `latvecs::AbstractMatrix{<:Real}`: the basis of the lattice as columns of a
     matrix.
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))`: a relative tolerance for
     floating point comparisons. It is used to compare lengths of vectors and the
@@ -47,35 +46,35 @@ SymmetryReduceBZ.Symmetry.calc_pointgroup(basis)
 """
 function calc_pointgroup(latvecs::AbstractMatrix{<:Real};
     rtol::Real=sqrt(eps(float(maximum(latvecs)))),
-    atol::Real=1e-9)::AbstractVector{AbstractMatrix{<:Real}}
+    atol::Real=1e-9)
 
-    dim=size(latvecs,1)
+    dim=checksquare(latvecs)
     latvecs = minkowski_reduce(latvecs,rtol=rtol,atol=atol)
-    radius = maximum([norm(latvecs[:,i]) for i=1:dim])*1.001
-    if size(latvecs) == (2,2)
+    radius = maximum([norm(latvecs[:,i]) for i=axes(latvecs,2)])*1.001
+    if dim == 2
         pts=sample_circle(latvecs,radius,[0,0],rtol=rtol,atol=atol)
-    elseif size(latvecs) == (3,3)
+    elseif dim == 3
         pts=sample_sphere(latvecs,radius,[0,0,0],rtol=rtol,atol=atol)
     else
         throw(ArgumentError("The lattice basis must be a 2x2 or 3x3 matrix."))
     end
 
-    normsᵢ=[norm(latvecs[:,i]) for i=1:dim]
+    normsᵢ=[norm(latvecs[:,i]) for i=axes(latvecs,2)]
     sizeᵢ=abs(det(latvecs))
-    pointgroup=Array{Array{Float64,2}}([])
+    pointgroup=Array{Float64,2}[]
     inv_latvecs=inv(latvecs)
     for perm=permutations(1:size(pts,2),dim)
         latvecsᵣ=pts[:,perm]
-        normsᵣ=[norm(latvecsᵣ[:,i]) for i=1:dim]
+        normsᵣ=[norm(latvecsᵣ[:,i]) for i=axes(latvecsᵣ,2)]
         sizeᵣ=abs(det(latvecsᵣ))
         # Point operation preserves length of lattice vectors and
         # volume of primitive cell.
-        if (isapprox(normsᵢ,normsᵣ,rtol=rtol,atol=atol) &
+        if (isapprox(normsᵢ,normsᵣ,rtol=rtol,atol=atol) &&
             isapprox(sizeᵢ,sizeᵣ,rtol=rtol,atol=atol))
             op=latvecsᵣ*inv_latvecs
             # Point operators are orthogonal.
             if isapprox(op'*op,I,rtol=rtol,atol=atol)
-                append!(pointgroup,[op])
+                push!(pointgroup,op)
             end
         end
     end
@@ -126,13 +125,12 @@ SymmetryReduceBZ.Symmetry.mapto_unitcell(pt,real_latvecs,inv_latvecs,
 function mapto_unitcell(pt::AbstractVector{<:Real},
     latvecs::AbstractMatrix{<:Real},inv_latvecs::AbstractMatrix{<:Real},
     coordinates::String;rtol::Real=sqrt(eps(float(maximum(inv_latvecs)))),
-    atol::Real=1e-9)::AbstractVector{<:Real}
+    atol::Real=1e-9)
+    T = promote_type(eltype(pt), eltype(latvecs), eltype(inv_latvecs))
     if coordinates == "Cartesian"
-        Array{Float64,1}(latvecs*[isapprox(mod(c,1),1,rtol=rtol) ? 0 : mod(c,1)
-            for c=inv_latvecs*pt])
+        latvecs*T[isapprox(mod(c,1),1,rtol=rtol) ? 0 : mod(c,1) for c=inv_latvecs*pt]
     elseif coordinates == "lattice"
-        Array{Float64,1}([isapprox(mod(c,1),1,rtol=rtol) ? 0 : mod(c,1) for
-            c=pt])
+        T[isapprox(mod(c,1),1,rtol=rtol) ? 0 : mod(c,1) for c=pt]
     else
         throw(ArgumentError("Allowed coordinates of the point are \"Cartesian\"
                 and \"lattice\"."))
@@ -147,10 +145,10 @@ Map points as columns of a matrix to the unitcell.
 function mapto_unitcell(points::AbstractMatrix{<:Real},
     latvecs::AbstractMatrix{<:Real},inv_latvecs::AbstractMatrix{<:Real},
     coordinates::String;rtol::Real=sqrt(eps(float(maximum(inv_latvecs)))),
-    atol::Real=1e-9)::AbstractMatrix{<:Real}
+    atol::Real=1e-9)
 
     reduce(hcat,[mapto_unitcell(points[:,i],latvecs,inv_latvecs,coordinates,
-        rtol=rtol,atol=atol) for i=1:size(points,2)])
+        rtol=rtol,atol=atol) for i=axes(points,2)])
 end
 
 @doc """
@@ -199,7 +197,7 @@ function mapto_bz(kpoint::AbstractVector{<:Real},
     recip_latvecs::AbstractMatrix{<:Real},
     inv_rlatvecs::AbstractMatrix{<:Real},coordinates::String;
     rtol::Real=sqrt(eps(float(maximum(recip_latvecs)))),
-    atol::Real=1e-9)::AbstractVector{<:Real}
+    atol::Real=1e-9)
 
     uc_point = mapto_unitcell(kpoint,recip_latvecs,inv_rlatvecs,coordinates,
         rtol=rtol,atol=atol)
@@ -232,6 +230,9 @@ function mapto_bz(kpoint::AbstractVector{<:Real},
         bz_point
     elseif coordinates == "lattice"
         inv_rlatvecs*bz_point
+    else
+        throw(ArgumentError("Allowed coordinates of the point are \"Cartesian\"
+        and \"lattice\"."))
     end
 end
 
@@ -244,10 +245,10 @@ function mapto_bz(kpoints::AbstractMatrix{<:Real},
     recip_latvecs::AbstractMatrix{<:Real},
     inv_rlatvecs::AbstractMatrix{<:Real},coordinates::String;
     rtol::Real=sqrt(eps(float(maximum(recip_latvecs)))),
-    atol::Real=1e-9)::AbstractMatrix{<:Real}
+    atol::Real=1e-9)
 
     reduce(hcat,[mapto_bz(kpoints[:,i],recip_latvecs,inv_rlatvecs,coordinates,
-        rtol=rtol, atol=atol) for i=1:size(kpoints,2)])
+        rtol=rtol, atol=atol) for i=axes(kpoints,2)])
 end
 
 @doc """
@@ -278,16 +279,16 @@ inhull(pt,convexhull)
 true
 ```
 """
-function inhull(point::AbstractVector{<:Real}, chull::Chull{Float64};
+function inhull(point::AbstractVector{<:Real}, chull::Chull{<:Real};
     rtol::Real=sqrt(eps(float(maximum(flatten(chull.points))))),
-    atol::Real=1e-9)::Bool
+    atol::Real=1e-9)
 
-    hullpts = Array(chull.points')
+    # hullpts = Array(chull.points')
     distances = chull.facets[:,end]
-    norms = Array(chull.facets[:,1:end-1]')
+    norms = chull.facets[:,begin:end-1]'
     inside = true
-    for i=1:length(distances)
-        s = dot(point + distances[i]*norms[:,i], norms[:,i])
+    for (dist,i)=zip(distances, axes(norms,2))
+        s = dot(point + dist*norms[:,i], norms[:,i])
 
         if !(s <= 0 || isapprox(s,0.0,rtol=rtol,atol=atol))
             inside = false
@@ -358,7 +359,7 @@ function mapto_ibz(kpoint::AbstractVector{<:Real},
         inv_rlatvecs::AbstractMatrix{<:Real}, ibz::Chull{Float64},
         pointgroup::Vector{Matrix{Float64}}, coordinates::String;
         rtol::Real=sqrt(eps(float(maximum(recip_latvecs)))),
-        atol::Real=1e-9)::AbstractVector{<:Real}
+        atol::Real=1e-9)
 
     bzpoint = mapto_bz(kpoint,recip_latvecs,inv_rlatvecs,coordinates,
         rtol=rtol,atol=atol)
@@ -385,10 +386,10 @@ function mapto_ibz(kpoints::AbstractMatrix{<:Real},
         inv_rlatvecs::AbstractMatrix{<:Real}, ibz::Chull{Float64},
         pointgroup::Vector{Matrix{Float64}}, coordinates::String,
         rtol::Real=sqrt(eps(float(maximum(recip_latvecs)))),
-        atol::Real=1e-9)::AbstractMatrix{<:Real}
+        atol::Real=1e-9)
 
     ibzpts = reduce(hcat,[mapto_ibz(kpoints[:,i],recip_latvecs,
-        inv_rlatvecs,ibz,pointgroup,coordinates) for i=1:size(kpoints,2)])
+        inv_rlatvecs,ibz,pointgroup,coordinates) for i=axes(kpoints,2)])
 
     unique_points(ibzpts,rtol=rtol,atol=atol)
 end
@@ -430,18 +431,19 @@ SymmetryReduceBZ.Symmetry.calc_spacegroup(real_latvecs,atom_types,atom_pos,
 ```
 """
 function calc_spacegroup(real_latvecs::AbstractMatrix{<:Real},
-    atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
+    atom_types::AbstractVector{<:Int},atom_pos_::AbstractMatrix{<:Real},
     coordinates::String;rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),
-    atol::Real=1e-9)::Tuple
+    atol::Real=1e-9)
 
-    if length(atom_types) != size(atom_pos,2)
+    if length(atom_types) != size(atom_pos_,2)
         throw(ArgumentError("The number of atom types and positions must be the
             same."))
     end
 
     # Place atom positions in Cartesian coordinates.
+    atom_pos_1, real_latvecs_1 = promote(atom_pos_, real_latvecs)
     if coordinates == "lattice"
-        atom_pos = real_latvecs*atom_pos
+        atom_pos_1 = real_latvecs_1*atom_pos_1
     end
 
     real_latvecs = minkowski_reduce(real_latvecs,rtol=rtol,atol=atol)
@@ -450,13 +452,12 @@ function calc_spacegroup(real_latvecs::AbstractMatrix{<:Real},
     numatoms = length(atom_types)
 
     # Map points to the primitive cell.
-    atom_pos = reduce(hcat,[mapto_unitcell(atom_pos[:,i],real_latvecs,
-                inv_latvecs,"Cartesian",rtol=rtol,atol=atol) for i=1:numatoms])
+    atom_pos = mapto_unitcell(atom_pos_1[:,1:numatoms],real_latvecs,inv_latvecs,"Cartesian",rtol=rtol,atol=atol)
 
-    ops_spacegroup=[]
-    trans_spacegroup=[]
+    ops_spacegroup=Array{Float64,2}[]
+    trans_spacegroup=Array{Float64,1}[]
     kindᵣ=atom_types[1]
-    opts = []
+    # opts = Array{Float64,1}[]
 
     # Atoms of the same type as the first atom.
     same_atoms=findall(x->x==kindᵣ,atom_types)
@@ -470,9 +471,9 @@ function calc_spacegroup(real_latvecs::AbstractMatrix{<:Real},
             ftrans = mapto_unitcell(atom_pos[:,atomᵢ]-posᵣ,real_latvecs,
                 inv_latvecs,"Cartesian",rtol=rtol,atol=atol)
 
-            if !contains(ftrans, opts)
-                append!(opts, [ftrans])
-            end
+            # if !contains(ftrans, opts)
+            #     push!(opts, ftrans)
+            # end
 
             # Check that all atoms land on the lattice when rotated and
             # translated.
@@ -488,20 +489,18 @@ function calc_spacegroup(real_latvecs::AbstractMatrix{<:Real},
                 if !mapped continue end
             end
             if mapped
-                append!(ops_spacegroup,[op])
-                append!(trans_spacegroup,[ftrans])
+                push!(ops_spacegroup,op)
+                push!(trans_spacegroup,ftrans)
             end
         end
     end
-    trans_spacegroup=convert(Array{Array{Float64,1}}, trans_spacegroup)
-    ops_spacegroup = convert(Array{Array{Float64,2},1},ops_spacegroup)
 
     (trans_spacegroup,ops_spacegroup)
 end
 
 @doc """
     calc_bz(real_latvecs,atom_types,atom_pos,coordinates,bzformat,makeprim,
-        convention;rtol,atol)
+        convention,library;rtol,atol)
 
 Calculate the Brillouin zone for the given real-space lattice basis.
 
@@ -509,7 +508,7 @@ Calculate the Brillouin zone for the given real-space lattice basis.
 - `real_latvecs::AbstractMatrix{<:Real}`: the real-space lattice vectors or
     primitive translation vectors as columns of a 2x2 or 3x3 matrix.
 - `atom_typesAbstractVector{<:Int}`: a list of atom types as integers.
-- `atom_pos::AbstractMatrix{<:Real}`: the positions of atoms in the crystal 
+- `atom_pos::AbstractMatrix{<:Real}`: the positions of atoms in the crystal
     structure as columns of a matrix.
 - `coordinates::String`: indicates the positions of the atoms are in \"lattice\"
     or \"Cartesian\" coordinates.
@@ -521,6 +520,7 @@ Calculate the Brillouin zone for the given real-space lattice basis.
     reciprocal space. The two conventions are ordinary (temporal) frequency and
     angular frequency. The transformation from real to reciprocal space is
     unitary if the convention is ordinary.
+- `library::Polyhedra.Library=DefaultLibrary()`: a polyhedron manipulation library
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))` a relative tolerance for
     floating point comparisons.
 - `atol::Real=1e-9`: an absolute tolerance for floating point comparisons.
@@ -553,33 +553,34 @@ Points on convex hull in original order:
 function calc_bz(real_latvecs::AbstractMatrix{<:Real},
     atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
     coordinates::String,bzformat::String,makeprim::Bool=false,
-    convention::String="ordinary";
+    convention::String="ordinary", library::Library=DefaultLibrary{float(eltype(real_latvecs))}();
     rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),atol::Real=1e-9)
 
     if makeprim
         (prim_latvecs,prim_types,prim_pos) = make_primitive(real_latvecs,
             atom_types,atom_pos,coordinates,rtol=rtol,atol=atol)
     else
-        (prim_types,prim_pos,prim_latvecs)=(atom_types,atom_pos,real_latvecs)
+        (prim_types,prim_pos,prim_latvecs)=(atom_types,float(atom_pos),float(real_latvecs))
     end
 
     recip_latvecs = minkowski_reduce(get_recip_latvecs(prim_latvecs,convention),
         rtol=rtol,atol=atol)
+    latpts_ = Vector{eltype(recip_latvecs)}[]
     if size(real_latvecs) == (2,2)
-        latpts = reduce(hcat,[recip_latvecs*[i,j] for (i,j)=product(-2:2,-2:2)])
+        append!(latpts_,[recip_latvecs*[i,j] for (i,j)=product(-2:2,-2:2)])
     elseif size(real_latvecs) == (3,3)
-        latpts = reduce(hcat,[recip_latvecs*[i,j,k] for (i,j,k)=product(-2:2,-2:2,-2:2)])
+        append!(latpts_,[recip_latvecs*[i,j,k] for (i,j,k)=product(-2:2,-2:2,-2:2)])
     else
         throw(ArgumentError("The lattice vectors must be a 2x2 or 3x3 matrix."))
     end
+    latpts = reduce(hcat, latpts_)
 
     distances = [norm(latpts[:,i]) for i=1:size(latpts,2)] .^2 ./2
-    bz = HalfSpace(latpts[:,2],distances[2])
-    for i=3:size(latpts,2)
+    bz = HalfSpace(latpts[:,2],distances[2]) ∩ HalfSpace(latpts[:,3],distances[3])
+    for i=4:size(latpts,2)
         bz = bz ∩ HalfSpace(latpts[:,i],distances[i])
     end
-
-    verts = reduce(hcat,points(polyhedron(bz,Library())))
+    verts = reduce(hcat,collect(points(polyhedron(bz, library))))
     bzvolume = chull(Array(verts')).volume
 
     if !(bzvolume ≈ abs(det(recip_latvecs)))
@@ -589,7 +590,7 @@ function calc_bz(real_latvecs::AbstractMatrix{<:Real},
     if bzformat == "half-space"
         bz
     elseif bzformat == "convex hull"
-        chull(Array(verts'))
+        chull(Array(verts'))    # chull is a type-unstable function
     else
         throw(ArgumentError("Formats for the BZ include \"half-space\" and
             \"convex hull\"."))
@@ -598,7 +599,7 @@ end
 
 @doc """
     calc_ibz(real_latvecs,atom_types,atom_pos,coordinates,ibzformat,makeprim,
-        convention;rtol,atol)
+        convention,library;rtol,atol)
 
 Calculate the irreducible Brillouin zone of a crystal structure in 2D or 3D.
 
@@ -618,6 +619,7 @@ Calculate the irreducible Brillouin zone of a crystal structure in 2D or 3D.
     reciprocal space. The two conventions are ordinary (temporal) frequency and
     angular frequency. The transformation from real to reciprocal space is
     unitary if the convention is ordinary.
+- `library::Polyhedra.Library=DefaultLibrary()`: a polyhedron manipulation library
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))` a relative tolerance for
     floating point comparisons.
 - `atol::Real=1e-9`: an absolute tolerance for floating point comparisons.
@@ -650,14 +652,14 @@ Points on convex hull in original order:
 function calc_ibz(real_latvecs::AbstractMatrix{<:Real},
     atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
     coordinates::String,ibzformat::String,makeprim::Bool=false,
-    convention::String="ordinary";
+    convention::String="ordinary", library::Library=DefaultLibrary{float(eltype(real_latvecs))}();
     rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),atol::Real=1e-9)
 
     if makeprim
         (prim_latvecs,prim_types,prim_pos) = make_primitive(real_latvecs,
             atom_types,atom_pos,coordinates,rtol=rtol,atol=atol)
     else
-        (prim_types,prim_pos,prim_latvecs)=(atom_types,atom_pos,real_latvecs)
+        (prim_types,prim_pos,prim_latvecs)=(atom_types,float(atom_pos),float(real_latvecs))
         if coordinates == "lattice"
             prim_pos = real_latvecs*prim_pos
         end
@@ -666,9 +668,11 @@ function calc_ibz(real_latvecs::AbstractMatrix{<:Real},
     pointgroup = remove_duplicates(calc_spacegroup(prim_latvecs,prim_types,
         prim_pos,"Cartesian",rtol=rtol,atol=atol)[2],rtol=rtol,atol=atol)
     sizepg = size(pointgroup,1)
-    bz = calc_bz(prim_latvecs,prim_types,prim_pos,"Cartesian","half-space",false,
+    # enforce type here due to instability in calc_bz
+    bz::Intersection{eltype(prim_latvecs), Vector{eltype(prim_latvecs)}, Int64} =
+        calc_bz(prim_latvecs,prim_types,prim_pos,"Cartesian","half-space",false,
         convention,rtol=rtol,atol=atol)
-    bz_vertices = collect(points(polyhedron(bz,Library())))
+    bz_vertices = collect(points(polyhedron(bz, library)))
     ibz = bz
     for v=bz_vertices
         for i=length(pointgroup):-1:1
@@ -685,11 +689,11 @@ function calc_ibz(real_latvecs::AbstractMatrix{<:Real},
         end
     end
 
-    ibz_vertices = reduce(hcat,points(polyhedron(ibz,Library())))
+    ibz_vertices = reduce(hcat,collect(points(polyhedron(ibz, library))))
     bz_vertices = reduce(hcat,bz_vertices)
     bzvolume = chull(Array(bz_vertices')).volume
     ibzvolume = chull(Array(ibz_vertices')).volume
-    reduction = bzvolume/ibzvolume
+    # reduction = bzvolume/ibzvolume
 
     if !(ibzvolume ≈ bzvolume/sizepg)
         @show ibzvolume
@@ -700,7 +704,7 @@ function calc_ibz(real_latvecs::AbstractMatrix{<:Real},
     if ibzformat == "half-space"
         ibz
     elseif ibzformat == "convex hull"
-        chull(Array(ibz_vertices'))
+        chull(Array(ibz_vertices')) # chull is type-unstable
     else
         throw(ArgumentError("Formats for the IBZ include \"half-space\" and
             \"convex hull\"."))
@@ -756,40 +760,40 @@ coordinates = "Cartesian"
 convention = "ordinary"
 make_primitive(real_latvecs, atom_types, atom_pos, coordinates)
 # output
-([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0]) 
+([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0])
 ```
 """
 function make_primitive(real_latvecs::AbstractMatrix{<:Real},
-    atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
+    atom_types::AbstractVector{<:Integer},atom_pos::AbstractMatrix{<:Real},
     coordinates::String;rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),
     atol::Real=1e-9)
 
     if length(atom_types) == 1
-        return (real_latvecs, atom_types, atom_pos)
+        return (float(real_latvecs), atom_types, float(atom_pos)) # fractional translations will be floating-point
     end
 
-    (ftrans, pg) = calc_spacegroup(real_latvecs,atom_types,atom_pos,coordinates,
+    (ftrans_, pg) = calc_spacegroup(real_latvecs,atom_types,atom_pos,coordinates,
         rtol=rtol,atol=atol)
     # Unique fractional translations
-    ftrans = unique_points(reduce(hcat, ftrans),rtol=rtol,atol=atol)
+    ftrans = unique_points(reduce(hcat, ftrans_),rtol=rtol,atol=atol)
 
     # No need to consider the origin.
     dim = size(real_latvecs,1)
-    if dim==2 
+    if dim==2
         origin=[0.,0.]
-    elseif dim==3 
+    elseif dim==3
         origin=[0.,0.,0.]
     else
         throw(ArgumentError("Can only make 2D or 3D unit cells primitive."))
     end
-    for i = 1:size(ftrans,2)
+    for i = axes(ftrans,2)
         if isapprox(ftrans[:,i],origin,rtol=rtol,atol=atol)
             ftrans  = ftrans[:,1:end .!= i]
             break
         end
     end
 
-    prim_latvecs = real_latvecs
+    prim_latvecs = similar(real_latvecs, promote_type(eltype(real_latvecs), eltype(ftrans)))
     inv_latvecs = inv(real_latvecs)
     mapped = false
     if size(ftrans,2)!=0
@@ -798,45 +802,44 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
         # Lattice vector options
         opts = hcat(real_latvecs, ftrans)
         if dim == 2
-            iters = [[(i,j) for j=i+1:nopts-1] for i=1:nopts-2] |> flatten
+            iters = [[i,j] for i=1:nopts-2 for j=i+1:nopts-1]
         else
-            iters = [[[(i,j,k) for k=j+1:nopts] for j=i+1:nopts-1] for 
-                i=1:nopts-2] |> flatten |> flatten
+            iters = [[i,j,k] for i=1:nopts-2 for j=i+1:nopts-1 for k=j+1:nopts]
         end
 
-        for iter=iters
-            prim_latvecs = opts[:,[iter...]]
+        for iter=reverse(iters)
+            prim_latvecs .= opts[:,iter]
             if isapprox(det(prim_latvecs),0,atol=atol)
                 continue
             end
-            inv_latvecs = inv(prim_latvecs)
+            inv_latvecs .= inv(prim_latvecs)
             # Move all lattice points into the potential primitive unit cell.
-            test = [mapto_unitcell(opts[:,i],prim_latvecs,
-                    inv_latvecs,"Cartesian",rtol=rtol,atol=atol) for i=1:nopts]
+            tests = mapto_unitcell(opts[:,1:nopts],prim_latvecs,
+                    inv_latvecs,"Cartesian",rtol=rtol,atol=atol)
             # Check if all coordinates of all fractional translations are
             # integers in lattice coordinates.
-            test = [inv_latvecs*t for t=test]
-            test = isapprox(mod.(collect(flatten(test)),1)
-                        ,zeros(dim*length(test)),rtol=rtol,atol=atol)
-            if test
+            test = [inv_latvecs*tests[:,i] for i=axes(tests,2)]
+            if isapprox(mod.(collect(flatten(test)),1)
+                ,zeros(dim*length(test)),rtol=rtol,atol=atol)
                 mapped = true
                 break
             end
         end
     end
-    
+
     if !mapped
-        prim_latvecs = real_latvecs
-        inv_latvecs = inv(real_latvecs)
+        prim_latvecs .= real_latvecs
+        inv_latvecs .= inv(real_latvecs)
     end
 
     # Map all atoms into the primitive cell.
-    all_prim_pos = atom_pos
+    all_prim_pos_ = similar(atom_pos, promote_type(eltype(real_latvecs), eltype(atom_pos)))
+    all_prim_pos_ .= atom_pos
     if coordinates == "lattice"
-        all_prim_pos = real_latvecs*all_prim_pos
+        all_prim_pos_ .= real_latvecs*all_prim_pos_
     end
-    all_prim_pos = reduce(hcat,[mapto_unitcell(all_prim_pos[:,i], prim_latvecs,
-        inv_latvecs,"Cartesian",rtol=rtol,atol=atol) for i=1:length(atom_types)])
+    all_prim_pos = mapto_unitcell(all_prim_pos_[:,1:length(atom_types)], prim_latvecs,
+        inv_latvecs,"Cartesian",rtol=rtol,atol=atol)
 
     # Remove atoms at the same positions that are the same type.
     tmp = unique_points(vcat(all_prim_pos,atom_types'),rtol=rtol,atol=atol)
@@ -853,11 +856,11 @@ Complete the orbit of a point.
 
 # Arguments
 - `pt::AbstractVector{<:Real}`: the Cartesian coordinates of a point.
-- `pointgroup::Vector{Matrix{Float64}}`: the point group operators 
-    in a nested list. The operators operate on points in Cartesian coordinates 
+- `pointgroup::Vector{Matrix{Float64}}`: the point group operators
+    in a nested list. The operators operate on points in Cartesian coordinates
     from the right.
 - `rtol::Real=sqrt(eps(float(maximum(pt))))`: a relative tolerance.
-- `atol::Real=1e-9`: an absolute tolerance. 
+- `atol::Real=1e-9`: an absolute tolerance.
 
 # Returns
 - `::AbstractMatrix{<:Real}`: the points of the orbit in Cartesian coordinates as
@@ -878,7 +881,7 @@ complete_orbit(pt,pointgroup)
 function complete_orbit(pt::AbstractVector{<:Real},
         pointgroup::Vector{Matrix{Float64}};
         rtol::Real=sqrt(eps(float(maximum(pt)))),
-        atol::Real=1e-9)::AbstractMatrix{<:Real}
+        atol::Real=1e-9)
     unique_points(reduce(hcat,map(op->op*pt,pointgroup)),rtol=rtol,atol=atol)
 end
 
@@ -890,10 +893,10 @@ Complete the orbits of multiple points.
 # Arguments
 - `pt::AbstractMatrix{<:Real}`: the Cartesian coordinates of a points as columns of
     a matrix.
-- `pointgroup::Vector{Matrix{Float64}}`: the point group operators 
+- `pointgroup::Vector{Matrix{Float64}}`: the point group operators
     in a nested list. The operators operate on points in Cartesian coordinates from the right.
 - `rtol::Real=sqrt(eps(float(maximum(pt))))`: a relative tolerance.
-- `atol::Real=1e-9`: an absolute tolerance. 
+- `atol::Real=1e-9`: an absolute tolerance.
 
 # Returns
 - `::AbstractMatrix{<:Real}`: the unique points of the orbits in Cartesian coordinates as
@@ -914,7 +917,7 @@ complete_orbit(pts,pointgroup)
 function complete_orbit(pts::AbstractMatrix{<:Real},
     pointgroup::Vector{Matrix{Float64}};
     rtol::Real=sqrt(eps(float(maximum(pts)))),
-    atol::Real=1e-9)::AbstractMatrix{<:Real}
-    unique_points(reduce(hcat,reduce(hcat,[map(op->op*pts[:,i],pointgroup) for i=1:size(pts,2)])))
+    atol::Real=1e-9)
+    unique_points(reduce(hcat,reduce(hcat,[map(op->op*pts[:,i],pointgroup) for i=axes(pts,2)])))
  end
 end #module

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -1,5 +1,6 @@
 module Symmetry
 
+import CDDLib
 import Polyhedra: HalfSpace, polyhedron, points, Intersection, Library, DefaultLibrary
 import LinearAlgebra: norm, det, I, dot, checksquare
 import QHull: chull, Chull
@@ -128,9 +129,9 @@ function mapto_unitcell(pt::AbstractVector{<:Real},
     atol::Real=1e-9)
     T = promote_type(eltype(pt), eltype(latvecs), eltype(inv_latvecs))
     if coordinates == "Cartesian"
-        latvecs*T[isapprox(mod(c,1),1,rtol=rtol) ? 0 : mod(c,1) for c=inv_latvecs*pt]
+        latvecs*T[isapprox(mod(c,1),1,rtol=rtol,atol=atol) ? 0 : mod(c,1) for c=inv_latvecs*pt]
     elseif coordinates == "lattice"
-        T[isapprox(mod(c,1),1,rtol=rtol) ? 0 : mod(c,1) for c=pt]
+        T[isapprox(mod(c,1),1,rtol=rtol,atol=atol) ? 0 : mod(c,1) for c=pt]
     else
         throw(ArgumentError("Allowed coordinates of the point are \"Cartesian\"
                 and \"lattice\"."))
@@ -520,7 +521,7 @@ Calculate the Brillouin zone for the given real-space lattice basis.
     reciprocal space. The two conventions are ordinary (temporal) frequency and
     angular frequency. The transformation from real to reciprocal space is
     unitary if the convention is ordinary.
-- `library::Polyhedra.Library=DefaultLibrary()`: a polyhedron manipulation library
+- `library::Polyhedra.Library=CDDLib.Library()`: a polyhedron manipulation library
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))` a relative tolerance for
     floating point comparisons.
 - `atol::Real=1e-9`: an absolute tolerance for floating point comparisons.
@@ -553,7 +554,7 @@ Points on convex hull in original order:
 function calc_bz(real_latvecs::AbstractMatrix{<:Real},
     atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
     coordinates::String,bzformat::String,makeprim::Bool=false,
-    convention::String="ordinary", library::Library=DefaultLibrary{float(eltype(real_latvecs))}();
+    convention::String="ordinary", library::Library=CDDLib.Library();
     rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),atol::Real=1e-9)
 
     if makeprim
@@ -619,7 +620,7 @@ Calculate the irreducible Brillouin zone of a crystal structure in 2D or 3D.
     reciprocal space. The two conventions are ordinary (temporal) frequency and
     angular frequency. The transformation from real to reciprocal space is
     unitary if the convention is ordinary.
-- `library::Polyhedra.Library=DefaultLibrary()`: a polyhedron manipulation library
+- `library::Polyhedra.Library=CDDLib.Library()`: a polyhedron manipulation library
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))` a relative tolerance for
     floating point comparisons.
 - `atol::Real=1e-9`: an absolute tolerance for floating point comparisons.
@@ -652,7 +653,7 @@ Points on convex hull in original order:
 function calc_ibz(real_latvecs::AbstractMatrix{<:Real},
     atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
     coordinates::String,ibzformat::String,makeprim::Bool=false,
-    convention::String="ordinary", library::Library=DefaultLibrary{float(eltype(real_latvecs))}();
+    convention::String="ordinary", library::Library=CDDLib.Library();
     rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),atol::Real=1e-9)
 
     if makeprim

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -807,7 +807,7 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
             iters = [[i,j,k] for i=1:nopts-2 for j=i+1:nopts-1 for k=j+1:nopts]
         end
 
-        for iter=reverse(iters)
+        for iter=iters
             prim_latvecs .= opts[:,iter]
             if isapprox(det(prim_latvecs),0,atol=atol)
                 continue

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -16,7 +16,7 @@ import ..Utilities: sample_circle, sample_sphere, contains, unique_points, remov
 Calculate the point group of a lattice in 2D or 3D.
 
 # Arguments
-- `latvecs::AbstractMatrix{<:Real}`: the basis of the lattice as columns of a
+- `latvecs::AbstractMatrix{<:Real}`: the basis of the lattice as columns of a 
     matrix.
 - `rtol::Real=sqrt(eps(float(maximum(real_latvecs))))`: a relative tolerance for
     floating point comparisons. It is used to compare lengths of vectors and the
@@ -509,7 +509,7 @@ Calculate the Brillouin zone for the given real-space lattice basis.
 - `real_latvecs::AbstractMatrix{<:Real}`: the real-space lattice vectors or
     primitive translation vectors as columns of a 2x2 or 3x3 matrix.
 - `atom_typesAbstractVector{<:Int}`: a list of atom types as integers.
-- `atom_pos::AbstractMatrix{<:Real}`: the positions of atoms in the crystal
+- `atom_pos::AbstractMatrix{<:Real}`: the positions of atoms in the crystal 
     structure as columns of a matrix.
 - `coordinates::String`: indicates the positions of the atoms are in \"lattice\"
     or \"Cartesian\" coordinates.
@@ -756,7 +756,7 @@ coordinates = "Cartesian"
 convention = "ordinary"
 make_primitive(real_latvecs, atom_types, atom_pos, coordinates)
 # output
-([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0])
+([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0]) 
 ```
 """
 function make_primitive(real_latvecs::AbstractMatrix{<:Real},
@@ -775,9 +775,9 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
 
     # No need to consider the origin.
     dim = size(real_latvecs,1)
-    if dim==2
+    if dim==2 
         origin=[0.,0.]
-    elseif dim==3
+    elseif dim==3 
         origin=[0.,0.,0.]
     else
         throw(ArgumentError("Can only make 2D or 3D unit cells primitive."))
@@ -800,7 +800,7 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
         if dim == 2
             iters = [[(i,j) for j=i+1:nopts-1] for i=1:nopts-2] |> flatten
         else
-            iters = [[[(i,j,k) for k=j+1:nopts] for j=i+1:nopts-1] for
+            iters = [[[(i,j,k) for k=j+1:nopts] for j=i+1:nopts-1] for 
                 i=1:nopts-2] |> flatten |> flatten
         end
 
@@ -824,7 +824,7 @@ function make_primitive(real_latvecs::AbstractMatrix{<:Real},
             end
         end
     end
-
+    
     if !mapped
         prim_latvecs = real_latvecs
         inv_latvecs = inv(real_latvecs)
@@ -853,11 +853,11 @@ Complete the orbit of a point.
 
 # Arguments
 - `pt::AbstractVector{<:Real}`: the Cartesian coordinates of a point.
-- `pointgroup::Vector{Matrix{Float64}}`: the point group operators
-    in a nested list. The operators operate on points in Cartesian coordinates
+- `pointgroup::Vector{Matrix{Float64}}`: the point group operators 
+    in a nested list. The operators operate on points in Cartesian coordinates 
     from the right.
 - `rtol::Real=sqrt(eps(float(maximum(pt))))`: a relative tolerance.
-- `atol::Real=1e-9`: an absolute tolerance.
+- `atol::Real=1e-9`: an absolute tolerance. 
 
 # Returns
 - `::AbstractMatrix{<:Real}`: the points of the orbit in Cartesian coordinates as
@@ -890,10 +890,10 @@ Complete the orbits of multiple points.
 # Arguments
 - `pt::AbstractMatrix{<:Real}`: the Cartesian coordinates of a points as columns of
     a matrix.
-- `pointgroup::Vector{Matrix{Float64}}`: the point group operators
+- `pointgroup::Vector{Matrix{Float64}}`: the point group operators 
     in a nested list. The operators operate on points in Cartesian coordinates from the right.
 - `rtol::Real=sqrt(eps(float(maximum(pt))))`: a relative tolerance.
-- `atol::Real=1e-9`: an absolute tolerance.
+- `atol::Real=1e-9`: an absolute tolerance. 
 
 # Returns
 - `::AbstractMatrix{<:Real}`: the unique points of the orbits in Cartesian coordinates as

--- a/src/SymmetryReduceBZ.jl
+++ b/src/SymmetryReduceBZ.jl
@@ -1,9 +1,9 @@
 module SymmetryReduceBZ
 
 include("Lattices.jl")
-include("Plotting.jl")
-include("Symmetry.jl")
 include("Utilities.jl")
+include("Symmetry.jl")
+include("Plotting.jl")
 
 import .Plotting: plot_convexhulls
 import .Symmetry: calc_bz, calc_ibz

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -400,11 +400,11 @@ shoelace(pts)
 1.0
 ````
 """
-function shoelace(vertices)
+function shoelace(vertices::AbstractMatrix{<:Real})
     xs = vertices[begin,:]
     ys = vertices[end,:]
     abs(xs[end]*ys[begin] - xs[begin]*ys[end] +
-        sum(i -> xs[i]*ys[i+1]-xs[i+1]*ys[i], first(axes(vertices,2), size(vertices,2)-1)))/2
+        sum(i -> xs[i]*ys[i+1]-xs[i+1]*ys[i], axes(vertices,2)[begin:end-1]))/2
 end
 
 @doc """

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -32,7 +32,7 @@ SymmetryReduceBZ.Utilities.affine_trans(pts)
   0.0   0.0   0.0  1.0
 ```
 """
-function affine_trans(pts::AbstractMatrix{<:Real})::AbstractMatrix{<:Real}
+function affine_trans(pts::AbstractMatrix{<:Real})
     a,b,c = [pts[:,i] for i=1:3]
 
     # Create a coordinate system with two vectors lying on the plane the points
@@ -54,7 +54,7 @@ end
 Check if a point is contained in a matrix of points as columns.
 
 # Arguments
-- `pt::AbstractVector{<:Real}`: a point whose coordinates are the components of 
+- `pt::AbstractVector{<:Real}`: a point whose coordinates are the components of
     a vector.
 - `pts::AbstractMatrix{<:Real}`: coordinates of points as columns of a matrix.
 - `rtol::Real=sqrt(eps(float(maximum(pts))))`: a relative tolerance for floating
@@ -259,10 +259,10 @@ SymmetryReduceBZ.Utilities.mapto_xyplane(pts)
  0.0  0.0  1.0  1.0
 ```
 """
-function mapto_xyplane(pts::AbstractMatrix{<:Real})::AbstractMatrix{<:Real}
+function mapto_xyplane(pts::AbstractMatrix{<:Real})
 
     M = affine_trans(pts)
-    reduce(hcat,[(M*[pts[:,i]..., 1])[1:2] for i=1:size(pts,2)])
+    mapslices(pt -> first(M*vcat(pt, 1), 2), pts, dims=1)
 end
 
 @doc """
@@ -271,7 +271,7 @@ end
 Sample uniformly within a circle centered about a point.
 
 ## Arguments
-- `basis::AbstractMatrix{<:Real}`: a 2x2 matrix whose columns are the grid 
+- `basis::AbstractMatrix{<:Real}`: a 2x2 matrix whose columns are the grid
     generating vectors.
 - `radius::Real`: the radius of the circle.
 - `offset::AbstractVector{<:Real}=[0.,0.]`: the xy-coordinates of the center of
@@ -493,7 +493,7 @@ SymmetryReduceBZ.Utilities.unique_points(points)
 function unique_points(points::AbstractMatrix{<:Real};
     rtol::Real=sqrt(eps(float(maximum(flatten(points))))),
     atol::Real=1e-9)::AbstractMatrix
-    
+
     uniquepts=zeros(size(points))
     numpts = 0
     for i=1:size(points,2)
@@ -514,10 +514,10 @@ Remove duplicates from an array.
 # Arguments
 - `points::AbstractVector`: items in a vector, which can be floats or arrays.
 - `rtol::Real=sqrt(eps(float(maximum(points))))`: relative tolerance.
-- `atol::Real=1e-9`: absolute tolerance. 
+- `atol::Real=1e-9`: absolute tolerance.
 
 # Returns
-- `uniquepts::AbstractVector`: an vector with only unique elements. 
+- `uniquepts::AbstractVector`: an vector with only unique elements.
 
 # Examples
 ```jldoctest
@@ -583,7 +583,7 @@ function points₋in₋ball(points::AbstractMatrix{<:Real},radius::Real,
     ball_points = zeros(Int,size(points,2))
     count = 0
     for i=1:size(points,2)
-        if (norm(points[:,i] - offset) < radius) || 
+        if (norm(points[:,i] - offset) < radius) ||
             isapprox(norm(points[:,i] - offset),radius,rtol=rtol,atol=atol)
             count+=1
             ball_points[count] = i

--- a/test/symmetry.jl
+++ b/test/symmetry.jl
@@ -8,6 +8,7 @@ import SymmetryReduceBZ.Symmetry: calc_spacegroup, calc_pointgroup, calc_bz,
 import SymmetryReduceBZ.Utilities: unique_points
 import SymmetryReduceBZ.Lattices: genlat_FCC, get_recip_latvecs
 
+import CDDLib: Library
 import LinearAlgebra: inv
 import QHull: chull
 import PyCall: pyimport
@@ -220,7 +221,7 @@ ibzformat="convex hull"
             @test length(pointgroup) == pgsizes[i]
         end
 
-        @test_throws ArgumentError calc_pointgroup([1 0])
+        @test_throws DimensionMismatch calc_pointgroup([1 0])
 
     end
 
@@ -246,8 +247,8 @@ ibzformat="convex hull"
                     for convention=["ordinary","angular"]
 
                         bz=calc_bz(real_latvecs,atom_types,atom_pos,coords,
-                            bzformat,makeprim,convention)
-                        
+                            bzformat,makeprim,convention,Library())
+
                         if makeprim
                         	(prim_latvecs,prim_types,prim_pos) = make_primitive(
                                 real_latvecs,atom_types,atom_pos,coords)
@@ -277,7 +278,7 @@ ibzformat="convex hull"
         convention="ordinary"
         bzformat="bad format"
         @test_throws ArgumentError bz=calc_bz(real_latvecs,atom_types,atom_pos,
-            coords,bzformat,primitive,convention)
+            coords,bzformat,primitive,convention,Library())
     end
 
     @testset "calc_ibz" begin
@@ -313,10 +314,10 @@ ibzformat="convex hull"
                         prim_pos,coords)[2]
 
                     bz=calc_bz(prim_latvecs,prim_types,prim_pos,coords,
-                        bzformat,makeprim,convention)
+                        bzformat,makeprim,convention,Library())
 
                     ibz=calc_ibz(prim_latvecs,prim_types,prim_pos,coords,
-                        ibzformat,makeprim,convention)
+                        ibzformat,makeprim,convention,Library())
 
                     # Unfold IBZ
                     unfoldpts=reduce(hcat,[op*(ibz.points[i,:]) for op=pointgroup
@@ -332,11 +333,11 @@ ibzformat="convex hull"
         end
         ibzformat="bad format"
         @test_throws ArgumentError calc_ibz(listreal_latvecs[1], [0],
-            Array([0 0]'), "lattice", ibzformat, false, "ordinary")
+            Array([0 0]'), "lattice", ibzformat, false, "ordinary", Library())
 
         passed = false
         ibz = calc_ibz(listreal_latvecs[1], [0,0], Array([0 0; 0.5 0.5]'),
-            "Cartesian", "half-space", true,"ordinary")
+            "Cartesian", "half-space", true,"ordinary", Library())
         passed = true
         @test passed
     end
@@ -375,7 +376,7 @@ ibzformat="convex hull"
         convention = "ordinary"
 
         bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,bz_format,makeprim,
-            convention)
+            convention,Library())
 
         recip_latvecs = real_latvecs
         inv_rlatvecs = inv(recip_latvecs)
@@ -400,7 +401,7 @@ ibzformat="convex hull"
         convention = "ordinary"
 
         bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,bz_format,makeprim,
-            convention)
+            convention,Library())
 
         recip_latvecs = real_latvecs
         inv_rlatvecs = inv(recip_latvecs)
@@ -428,7 +429,7 @@ ibzformat="convex hull"
         convention = "ordinary"
 
         bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,bz_format,makeprim,
-            convention)
+            convention,Library())
 
         kpoint = [1.2,0]
         @test inhull(kpoint,bz) == false
@@ -454,7 +455,7 @@ ibzformat="convex hull"
         convention = "ordinary"
 
         bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,bz_format,makeprim,
-            convention)
+            convention,Library())
 
         kpoint = [1.2,0,0]
         @test inhull(kpoint,bz) == false
@@ -488,7 +489,7 @@ ibzformat="convex hull"
         inv_rlatvecs = inv(recip_latvecs)
 
 
-        ibz = calc_ibz(real_latvecs,atom_types,atom_pos,coords,ibz_format,makeprim,convention)
+        ibz = calc_ibz(real_latvecs,atom_types,atom_pos,coords,ibz_format,makeprim,convention,Library())
         (ftrans, pointgroup)=calc_spacegroup(real_latvecs,atom_types,atom_pos,coords)
 
         kpoint = [1.2,0]
@@ -512,7 +513,7 @@ ibzformat="convex hull"
         recip_latvecs = get_recip_latvecs(real_latvecs,convention)
         inv_rlatvecs = inv(recip_latvecs)
 
-        ibz = calc_ibz(real_latvecs,atom_types,atom_pos,coords,ibz_format,makeprim,convention)
+        ibz = calc_ibz(real_latvecs,atom_types,atom_pos,coords,ibz_format,makeprim,convention,Library())
         (ftrans, pointgroup)=calc_spacegroup(real_latvecs,atom_types,atom_pos,coords)
 
         kpoint = [1.2,0,0]

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -9,6 +9,8 @@ import SymmetryReduceBZ.Lattices: genlat_SQR, genlat_REC, genlat_RECI, genlat_HX
 
 import SymmetryReduceBZ.Symmetry: calc_bz
 
+import CDDLib: Library
+
 # Lattice vectors
 # 2D
 a=5/7.
@@ -91,7 +93,7 @@ bzformat = "convex hull"
 		makeprim = false
 
 		bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,bzformat,makeprim,
-			convention)
+			convention,Library())
 
         facetsᵢ = get_uniquefacets(bz)
         facets = [bz.points[facetsᵢ[i],:] for i=1:length(facetsᵢ)]
@@ -185,7 +187,7 @@ bzformat = "convex hull"
 			coords = "Cartesian"
 			makeprim = false
 			bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,bzformat,
-				makeprim,convention)
+				makeprim,convention,Library())
 
             svol = shoelace(bz.points[bz.vertices,:]')
             @test svol ≈ bz.volume


### PR DESCRIPTION
Hi, I went through the `Lattices`, `Utilities`, and `Symmetries` submodules and did what I could to make them more type stable. This pr also includes the `Revise` and `QHull` related prs I made separately. All the changes are internal so that the tests still pass and the API is the same.

Overall, the output of `calc_bz` and `calc_ibz` is inferrable to within the two `hullformat` possibilities and I saw the time-to-first-ibz reduce by 3 seconds on my laptop. Another observation is that the CDDLib.jl library leads to type instabilities, so I made the polyhedral library an optional argument to the `calc_bz` and `calc_ibz` routines to allow users to choose their own library.